### PR TITLE
Feature/ecbuild_use_package_quiet

### DIFF
--- a/cmake/ecbuild_use_package.cmake
+++ b/cmake/ecbuild_use_package.cmake
@@ -303,7 +303,9 @@ macro( ecbuild_use_package )
       ecbuild_debug_var( _p_FAILURE_MSG )
       list( APPEND _opts FAILURE_MSG "${_p_FAILURE_MSG}" )
     endif()
-
+    if( _p_QUIET )
+        list( APPEND _opts QUIET )
+    endif()
     ecbuild_find_package( NAME ${_p_PROJECT} ${_opts} )
 
     if( ${_p_PROJECT}_FOUND )


### PR DESCRIPTION
Propagate the QUIET flag from ecbuild_use_package to ecbuild_find_package.  This will reduce noise when adding optional dependencies with ecbuild_use_package.

This PR completes the work begun with [JCSDA/ufo PR #337](https://github.com/JCSDA/ufo/pull/337) 