### PR TITLE
Feature/ecmwf sync

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -21,6 +21,20 @@ bootstrapped::
    ECBUILD_INSTALL_DIR=/usr/local/apps/ecbuild # where to install ecBuild
    $ECBUILD_SRC_DIR/bin/ecbuild --prefix=$ECBUILD_INSTALL_DIR $ECBUILD_SRC_DIR
 
+Generating documentation
+========================
+
+The documentation is generated using Sphinx. Make sure that ``sphinx-build``
+can be located using ``PATH`` or ``CMAKE_PREFIX_PATH``. You can either add the
+``-DSPHINX_HTML=ON`` option (as well as ``-DCMAKE_PREFIX_PATH=...`` if needed)
+to the above ``ecbuild`` command, or re-run ecBuild::
+
+   cd $TMPDIR/ecbuild
+   $ECBUILD_SRC_DIR/bin/ecbuild -DSPHINX_HTML=ON .
+   make documentation
+
+The documentation tree will be available in ``$TMPDIR/ecbuild/doc/html``.
+
 Running the tests
 =================
 

--- a/cmake/ecbuild_generate_fortran_interfaces.cmake
+++ b/cmake/ecbuild_generate_fortran_interfaces.cmake
@@ -12,15 +12,58 @@
 # ecbuild_generate_fortran_interfaces
 # ===================================
 #
-# Generates interfaces from the Fortran source files. ::
+# Generates interfaces from Fortran source files. ::
 #
-#   ecbuild_generate_fortran_interfaces()
+#   ecbuild_generate_fortran_interfaces( TARGET <name>
+#                                        DESTINATION <path>
+#                                        DIRECTORIES <directory1> [<directory2> ...]
+#                                        [ PARALLEL <integer> ]
+#                                        [ INCLUDE_DIRS <name> ]
+#                                        [ GENERATED <name> ]
+#                                        [ SOURCE_DIR <path> ]
+#                                        [ SUFFIX <suffix> ]
+#                                        [ FCM_CONFIG_FILE <file> ]
+#                                      )
 #
 # Options
 # -------
 #
 # TARGET : required
 #   target name
+#
+# DESTINATION : required
+#   sub-directory of ``CMAKE_CURRENT_BINARY_DIR`` to install target to
+#
+# DIRECTORIES : required
+#   list of directories in ``SOURCE_DIR`` in which to search for Fortran files to be processed
+#
+# PARALLEL : optional, defaults to 1
+#   number of processes to use (always 1 on Darwin systems)
+#
+# INCLUDE_DIRS : optional
+#   name of CMake variable to store the path to the include directory containing the resulting interfaces
+#
+# GENERATED : optional
+#   name of CMake variable to store the list of generated interface files, including the full path to each
+#
+# SOURCE_DIR : optional, defaults to ``CMAKE_CURRENT_SOURCE_DIR``
+#   directory in which to look for the sub-directories given as arguments to ``DIRECTORIES``
+#
+# SUFFIX : optional, defaults to ".intfb.h"
+#   suffix to apply to name of each interface file
+#
+# FCM_CONFIG_FILE : optional, defaults to the ``fcm-make-interfaces.cfg`` file in the ecbuild project
+#   FCM configuration file to be used to generate interfaces
+#
+# Usage
+# _____
+#
+# The listed directories will be recursively searched for Fortran files of the
+# form ``<fname>.[fF]``, ``<fname>.[fF]90``, ``<fname>.[fF]03`` or
+# ``<fname>.[fF]08``. For each matching file, a file ``<fname><suffix>`` will be
+# created containing the interface blocks for all external subprograms within
+# it, where ``<suffix>`` is the value given to the ``SUFFIX`` option. If a file
+# contains no such subprograms, no interface file will be generated for it.
 #
 ##############################################################################
 

--- a/examples/find_package/projects/fftw/test_fftw.cc
+++ b/examples/find_package/projects/fftw/test_fftw.cc
@@ -26,8 +26,8 @@ int main(int argc, char* argv[] ) {
   fftw->out = fftwf_alloc_real( nlats * nlons );
 
   fftw->plan =
-     fftwf_plan_many_dft_c2r( 1, &nlons, nlats, fftw->in, nullptr, 1, num_complex,
-                             fftw->out, nullptr, 1, nlons, FFTW_ESTIMATE );
+     fftwf_plan_many_dft_c2r( 1, &nlons, nlats, fftw->in, NULL, 1, num_complex,
+                             fftw->out, NULL, 1, nlons, FFTW_ESTIMATE );
 
   int idx = 0;
   for ( int jlat = 0; jlat < nlats; jlat++ ) {


### PR DESCRIPTION
Before tagging our fork of ecbuild, I thought we should bring it up to date with the latest changes at ecmwf.  So, this just merges ```ecmwf::develop``` into ```jcsda::develop```.