### PR TITLE
Improve FindNetCDF

### DIFF
--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -33,9 +33,8 @@
 #
 #   - NetCDF_<comp>_FOUND         - whether the component is found
 #   - NetCDF_<comp>_LIBRARIES     - the libraries for the component
-#   - NetCDF_<comp>_LIBRARY_STATIC - Boolean is true if libraries for component are static
 #   - NetCDF_<comp>_LIBRARY_SHARED - Boolean is true if libraries for component are shared
-#   - NetCDF_<comp>_INCLUDE_DIRS  - the include directories for specfied component
+#   - NetCDF_<comp>_INCLUDE_DIRS  - the include directories for specified component
 #   - NetCDF::NetCDF_<comp>       - target of component to be used with target_link_libraries()
 #
 # The following paths will be searched in order if set in CMake (first priority) or environment (second priority)
@@ -53,12 +52,12 @@
 #
 #   - Each variable is also available in fully uppercased version
 #   - Preferred naming for this package and it's variables is "NetCDF"
-#     For compatability, each variable not in targets, can subsititue "NetCDF" with
+#     For compatibility, each variable not in targets, can substitute "NetCDF" with
 #        * NetCDF4
 #        * NETCDF
 #        * NETCDF4
 #   - Preferred component capitalisation follows the CMake LANGUAGES variables.
-#     For compatability, capitalisation of COMPONENT arguments does not matter.
+#     For compatibility, capitalisation of COMPONENT arguments does not matter.
 #     The <comp> part of variables will be defined with:
 #        * capitalisation as defined above
 #        * Uppercase capitalisation
@@ -102,7 +101,7 @@ endif()
 
 ## Search hints for finding include directories and libraries
 foreach( _comp IN ITEMS "_" "_C_" "_Fortran_" "_CXX_" )
-  foreach( _name IN ITEMS NetCDF4 NetCDF NETCDF4 NETCDF4 )
+  foreach( _name IN ITEMS NetCDF4 NetCDF NETCDF4 NETCDF )
     foreach( _var IN ITEMS ROOT PATH )
       list(APPEND _search_hints ${${_name}${_comp}${_var}} $ENV{${_name}${_comp}${_var}} )
       list(APPEND _include_search_hints 
@@ -129,7 +128,9 @@ foreach( _comp IN LISTS _search_components )
     list(APPEND NetCDF_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIR})
   endif()
 endforeach()
-list(REMOVE_DUPLICATES NetCDF_INCLUDE_DIRS)
+if(NetCDF_INCLUDE_DIRS)
+    list(REMOVE_DUPLICATES NetCDF_INCLUDE_DIRS)
+endif()
 set(NetCDF_INCLUDE_DIRS "${NetCDF_INCLUDE_DIRS}" CACHE STRING "NetCDF Include directory paths" FORCE)
 
 ## Find nc-config executable
@@ -175,12 +176,10 @@ foreach( _comp IN LISTS _search_components )
 
   if( NetCDF_${_comp}_LIBRARY )
     if( NetCDF_${_comp}_LIBRARY MATCHES ".a$" )
-      set( NetCDF_${_comp}_LIBRARY_STATIC TRUE )
       set( NetCDF_${_comp}_LIBRARY_SHARED FALSE )
       set( _library_type STATIC)
     else()
       list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
-      set( NetCDF_${_comp}_LIBRARY_STATIC FALSE )
       set( NetCDF_${_comp}_LIBRARY_SHARED TRUE )
       set( _library_type SHARED)
     endif()

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -110,6 +110,7 @@ foreach( _comp IN ITEMS "_" "_C_" "_Fortran_" "_CXX_" )
     endforeach()
   endforeach()
 endforeach()
+list(APPEND _search_hints ${NETCDF} $ENV{NETCDF}) #Old-school HPC module env variable names
 
 ## Find headers for each component
 set(NetCDF_INCLUDE_DIRS)

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -17,7 +17,10 @@
 #   - NetCDF_CONFIG_EXECUTABLE    - the netcdf-config executable if found
 #   - NetCDF_PARALLEL             - Boolean True if NetCDF4 has parallel IO support via hdf5 and/or pnetcdf
 #   - NetCDF_HAS_PNETCDF          - Boolean True if NetCDF4 has pnetcdf support
-
+#
+# Deprecated Defines
+#   - NetCDF_LIBRARIES            - [Deprected] Use NetCDF::NetCDF_<LANG> targets instead.
+#
 #
 # Following components are available:
 #
@@ -176,6 +179,7 @@ foreach( _comp IN LISTS _search_components )
       set( NetCDF_${_comp}_LIBRARY_SHARED FALSE )
       set( _library_type STATIC)
     else()
+      list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
       set( NetCDF_${_comp}_LIBRARY_STATIC FALSE )
       set( NetCDF_${_comp}_LIBRARY_SHARED TRUE )
       set( _library_type SHARED)
@@ -208,7 +212,6 @@ foreach( _comp IN LISTS _search_components )
         INTERFACE_INCLUDE_DIRECTORIES ${NetCDF_${_comp}_INCLUDE_DIRS}
         INTERFACE_LINK_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
     endif()
-    list( APPEND NetCDF_LIBRARIES NetCDF::NetCDF_${_comp} )
   endif()
 endforeach()
 set(NetCDF_LIBRARIES "${NetCDF_LIBRARIES}" CACHE STRING "NetCDF library targets" FORCE)

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -96,7 +96,7 @@ foreach( _comp ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS} )
   endif()
 endforeach()
 if( NOT _search_components )
-  set( _search_components C Fortran )
+  set( _search_components C)
 endif()
 
 ## Search hints for finding include directories and libraries

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -19,7 +19,7 @@
 #   - NetCDF_HAS_PNETCDF          - Boolean True if NetCDF4 has pnetcdf support
 #
 # Deprecated Defines
-#   - NetCDF_LIBRARIES            - [Deprected] Use NetCDF::NetCDF_<LANG> targets instead.
+#   - NetCDF_LIBRARIES            - [Deprecated] Use NetCDF::NetCDF_<LANG> targets instead.
 #
 #
 # Following components are available:
@@ -50,20 +50,17 @@
 #
 # Notes:
 #
-#   - Each variable is also available in fully uppercased version
-#   - Preferred naming for this package and it's variables is "NetCDF"
-#     For compatibility, each variable not in targets, can substitute "NetCDF" with
-#        * NetCDF4
-#        * NETCDF
-#        * NETCDF4
-#   - Preferred component capitalisation follows the CMake LANGUAGES variables.
-#     For compatibility, capitalisation of COMPONENT arguments does not matter.
-#     The <comp> part of variables will be defined with:
-#        * capitalisation as defined above
-#        * Uppercase capitalisation
-#        * capitalisation as used in find_package() arguments
-#   - If no components are defined, all components will be searched without guarantee that the 
-#     required component is available.
+#   - Use "NetCDF::NetCDF_<LANG>" targets only.  NetCDF_LIBRARIES exists for backwards compatibility and should not be used.
+#     - These targets have all the knowledge of include directories and library search directories, and a single
+#       call to target_link_libraries will provide all these transitive properties to your target.  Normally all that is
+#       needed to build and link against NetCDF is, e.g.:
+#           target_link_libraries(my_c_tgt PUBLIC NetCDF::NetCDF_C)
+#   - "NetCDF" is always the preferred naming for this package, its targets, variables, and environment variables
+#     - For compatibility, some variables are also set/checked using alternate names NetCDF4, NETCDF, or NETCDF4
+#     - Environments relying on these older environment variable names should move to using a "NetCDF_ROOT" environment variable
+#   - Preferred component capitalization follows the CMake LANGUAGES variables: i.e., C, Fortran, CXX
+#     - For compatibility, alternate capitalizations are supported but should not be used.
+#   - If no components are defined, all components will be searched
 #
 
 list( APPEND _possible_components C CXX Fortran CXX_LEGACY )

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -105,8 +105,8 @@ foreach( _comp IN ITEMS "_" "_C_" "_Fortran_" "_CXX_" )
     foreach( _var IN ITEMS ROOT PATH )
       list(APPEND _search_hints ${${_name}${_comp}${_var}} $ENV{${_name}${_comp}${_var}} )
       list(APPEND _include_search_hints 
-                ${${_name}${_comp}INCLUDE_DIR} $ENV{${_name}${_comp}INCLUDE_DIR}} 
-                ${${_name}${_comp}INCLUDE_DIRS} $ENV{${_name}${_comp}INCLUDE_DIRS}} )
+                ${${_name}${_comp}INCLUDE_DIR} $ENV{${_name}${_comp}INCLUDE_DIR}
+                ${${_name}${_comp}INCLUDE_DIRS} $ENV{${_name}${_comp}INCLUDE_DIRS} )
     endforeach()
   endforeach()
 endforeach()
@@ -175,11 +175,11 @@ foreach( _comp IN LISTS _search_components )
 
 
   if( NetCDF_${_comp}_LIBRARY )
+    list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
     if( NetCDF_${_comp}_LIBRARY MATCHES ".a$" )
       set( NetCDF_${_comp}_LIBRARY_SHARED FALSE )
       set( _library_type STATIC)
     else()
-      list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
       set( NetCDF_${_comp}_LIBRARY_SHARED TRUE )
       set( _library_type SHARED)
     endif()

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -126,6 +126,7 @@ foreach( _comp IN LISTS _search_components )
     list(APPEND NetCDF_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIR})
   endif()
 endforeach()
+list(REMOVE_DUPLICATES NetCDF_INCLUDE_DIRS)
 set(NetCDF_INCLUDE_DIRS "${NetCDF_INCLUDE_DIRS}" CACHE STRING "NetCDF Include directory paths" FORCE)
 
 ## Find nc-config executable
@@ -192,7 +193,6 @@ foreach( _comp IN LISTS _search_components )
   #Use nc-config to set per-component INCLUDE_DIRS variable if possible
   nc_config( ${_${_comp}_ncflags_flag} _val )
   if( _val )
-    message("_val:${_val}")
     list(TRANSFORM _val REPLACE "-I" "")
     set( NetCDF_${_comp}_INCLUDE_DIRS ${_val} )
   else()


### PR DESCRIPTION
* Check for and export static libraries
* Check additional environment variables for include directories

This should work with `apps/jedi/gcc-7.3_openmpi-3.0.0-baselibs` as is.  

We probably do want to update those modules at some point to clean it up.  One issue was capitalization.  CMake wants "NetCDF", but the modules use "NETCDF", for compatibility, I'm checking for both, but ideally, the capitalization of environment variables for CMake consumption should match the corresponding `Find<PackageName>.cmake` capitalization.