### PR TITLE
Only print out NetCDF components and status once per-package

### DIFF
--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -269,10 +269,13 @@ set(NetCDF_PARALLEL ${_val} CACHE STRING "NetCDF has parallel IO capability via 
 
 ## Finalize find_package
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args( ${CMAKE_FIND_PACKAGE_NAME}
-  REQUIRED_VARS NetCDF_INCLUDE_DIRS NetCDF_LIBRARIES
-  VERSION_VAR NetCDF_VERSION
-  HANDLE_COMPONENTS )
+
+if(NOT NetCDF_FOUND OR _new_search_components)
+    find_package_handle_standard_args( ${CMAKE_FIND_PACKAGE_NAME}
+        REQUIRED_VARS NetCDF_INCLUDE_DIRS NetCDF_LIBRARIES
+        VERSION_VAR NetCDF_VERSION
+        HANDLE_COMPONENTS )
+endif()
 
 foreach( _comp IN LISTS _search_components )
     if( NetCDF_${_comp}_FOUND )


### PR DESCRIPTION
The new FindNetCDF prints out multiple times per package, in cases where transitive dependencies also call `find_package(NetCDF)` from within their exported CMake package config files.

Importantly the current design will "find" netcdf multiple times for one package because different dependencies may have requested different language components.  This all works fine for multiple calls.  The only problem is that we don't want to print 8 times when building `fv3-jedi` for example.  This fix will only print if a "new" component was found during the current call.  It will print once per package either from within a bundle or as a stand-alone package.