### PR TITLE
add recursive clone ability in ecbuild

### DIFF
--- a/cmake/ecbuild_bundle.cmake
+++ b/cmake/ecbuild_bundle.cmake
@@ -64,8 +64,9 @@ endmacro()
 #   ecbuild_bundle( PROJECT <name>
 #                   STASH <repository> | GIT <giturl> | SOURCE <path>
 #                   [ BRANCH <gitbranch> | TAG <gittag> ]
-#                   [ UPDATE | NOREMOTE ] )
-#                   [ MANUAL ] )
+#                   [ UPDATE | NOREMOTE ]
+#                   [ MANUAL ]
+#                   [ RECURSIVE ] )
 #
 # Options
 # -------
@@ -96,6 +97,9 @@ endmacro()
 #
 # MANUAL : optional
 #   Do not automatically switch branches or tags
+#
+# RECURSIVE : optional
+#   Do a recursive fetch or update
 #
 # Usage
 # -----

--- a/cmake/ecbuild_git.cmake
+++ b/cmake/ecbuild_git.cmake
@@ -26,8 +26,9 @@ endif()
 #                DIR <directory>
 #                URL <giturl>
 #                [ BRANCH <gitbranch> | TAG <gittag> ]
-#                [ UPDATE | NOREMOTE ] )
-#                [ MANUAL ] )
+#                [ UPDATE | NOREMOTE ]
+#                [ MANUAL ]
+#                [ RECURSIVE ] )
 #
 # Options
 # -------
@@ -56,11 +57,14 @@ endif()
 # MANUAL : optional
 #   Do not automatically switch branches or tags
 #
+# RECURSIVE : optional
+#   Do a recursive fetch or update
+#
 ##############################################################################
 
 macro( ecbuild_git )
 
-  set( options UPDATE NOREMOTE MANUAL )
+  set( options UPDATE NOREMOTE MANUAL RECURSIVE )
   set( single_value_args PROJECT DIR URL TAG BRANCH )
   set( multi_value_args )
   cmake_parse_arguments( _PAR "${options}" "${single_value_args}" "${multi_value_args}" ${_FIRST_ARG} ${ARGN} )
@@ -223,6 +227,16 @@ macro( ecbuild_git )
         endif()
 
       endif() ####################################################################################
+
+      if( _PAR_RECURSIVE )
+        ecbuild_info("git submodule --quiet update --init --recursive @ ${ABS_PAR_DIR}")
+        execute_process( COMMAND "${GIT_EXECUTABLE}" submodule --quiet update --init --recursive -q
+                        RESULT_VARIABLE nok ERROR_VARIABLE error
+                        WORKING_DIRECTORY "${ABS_PAR_DIR}")
+        if(nok)
+          ecbuild_warn("git submodule update --init --recursive in ${_PAR_DIR} failed:\n ${error}")
+        endif()
+      endif()
 
     endif( _needs_switch AND IS_DIRECTORY "${_PAR_DIR}/.git" )
 


### PR DESCRIPTION
**This is a draft PR**

For a long time, we have been forking third-party repositories if they are submodules of a repository we use or co-develop. Examples are `mom6` and its dependencies e.g. `CVmix`, `geoKdtree`, `mom6-da-hooks` and now `ocean_bgc`.
This adds burden on us to maintain the `ecbuild` layer on these as well as keeping them in sync.

With the option to `recursive`-ly clone/update these via the `ecbuild_bundle`, this makes the job much easier and allows us to obtain the appropriate `SHA` of these dependencies as they relate to the upstream repository. 

An example of this is demonstrated in `mom6-bundle`. Clone the branch `feature/recursion` from [mom6-bundle](https://github.com/aerorahul/mom6-bundle) and use the branch with the same name in `ecbuild`.

Change-Id: I3ff929b8ceb166da9737cd98b02037f80c766888

> Our plan is to have our develop branch mirror upstream develop. Then the normal workflow would be to create a feature branch on our fork from develop and issue a PR upstream. So, the PR would still come from the JCSDA fork. You can add JCSDA reviewers to the upstream PR.
> 
> I'm not sure how best to handle JCSDA discussions that might precede an upstream PR. Creating a draft PR as you have done might be a good solution. But, we plan to protect the develop and master branches so I'm not sure if users with write privileges can issue a draft PR on a protected branch.

@mmiesch I created an upstream PR to `ecmwf::ecbuild`. I am unable to add reviewers.
