### PR TITLE
Fix: PATH_VARS unused in ecbuild_generate_project_config()

### DIFF
--- a/cmake/ecbuild_generate_project_config.cmake
+++ b/cmake/ecbuild_generate_project_config.cmake
@@ -67,7 +67,7 @@ function(ecbuild_generate_project_config template)
 
   configure_package_config_file(${template} ${PROJECT_BINARY_DIR}/${_PAR_FILENAME}
     INSTALL_DESTINATION .
-    PATH_VARS BASE_DIR CMAKE_DIR ${PATH_VARS}
+    PATH_VARS BASE_DIR CMAKE_DIR ${_PAR_PATH_VARS}
     INSTALL_PREFIX ${PROJECT_BINARY_DIR}
   )
 
@@ -79,7 +79,7 @@ function(ecbuild_generate_project_config template)
   configure_package_config_file(${template}
     ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_PAR_FILENAME}
     INSTALL_DESTINATION ${INSTALL_CMAKE_DIR}
-    PATH_VARS BASE_DIR CMAKE_DIR ${PATH_VARS}
+    PATH_VARS BASE_DIR CMAKE_DIR ${_PAR_PATH_VARS}
   )
 install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_PAR_FILENAME}" DESTINATION "${INSTALL_CMAKE_DIR}")
 endfunction()


### PR DESCRIPTION
In ecbuild_generate_project_config(), PATH_VARS parameters must be accessed via _PAR_PATH_VARS name.  

Fixing this will allow us to correctly pass path variables as part of the generated cmake package config in both install and build-tree contexts.

This is a blocker for [oops # 639](https://github.com/jcsda/oops/pull/639), so merging and rebuilding containers will be required before that PR can pass the tests.