### PR TITLE
ecbuild_remove_fotran_flags uses incorrect REGEX

### DIFF
--- a/cmake/ecbuild_remove_fortran_flags.cmake
+++ b/cmake/ecbuild_remove_fortran_flags.cmake
@@ -44,15 +44,15 @@ macro( ecbuild_remove_fortran_flags m_flags )
     if( _PAR_BUILD AND (CMAKE_BUILD_TYPE_CAPS MATCHES "${_PAR_BUILD_CAPS}") )
 
       foreach( _flag ${_flags} )
-        string(REGEX REPLACE " *${_flag} *" " " CMAKE_Fortran_FLAGS_${_PAR_BUILD} ${CMAKE_Fortran_FLAGS_${_PAR_BUILD}})
+        string(REGEX REPLACE "(^|[ ]+)${flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${_PAR_BUILD} ${CMAKE_Fortran_FLAGS_${_PAR_BUILD}})
         ecbuild_debug( "Fortran FLAG [${_flag}] removed from build type ${_PAR_BUILD}" )
       endforeach()
 
     elseif( NOT _PAR_BUILD )
 
       foreach( _flag ${_flags} )
-        string(REGEX REPLACE " *${_flag} *" " " CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS} ${CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS}} )
-        string(REGEX REPLACE " *${_flag} *" " " CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS} )
+        string(REGEX REPLACE "(^|[ ]+)${flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS} ${CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS}} )
+        string(REGEX REPLACE "(^|[ ]+)${flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS} )
         ecbuild_debug( "Fortran FLAG [${_flag}] removed" )
       endforeach()
 

--- a/cmake/ecbuild_remove_fortran_flags.cmake
+++ b/cmake/ecbuild_remove_fortran_flags.cmake
@@ -44,15 +44,15 @@ macro( ecbuild_remove_fortran_flags m_flags )
     if( _PAR_BUILD AND (CMAKE_BUILD_TYPE_CAPS MATCHES "${_PAR_BUILD_CAPS}") )
 
       foreach( _flag ${_flags} )
-        string(REGEX REPLACE "(^|[ ]+)${flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${_PAR_BUILD} ${CMAKE_Fortran_FLAGS_${_PAR_BUILD}})
+        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${_PAR_BUILD} ${CMAKE_Fortran_FLAGS_${_PAR_BUILD}})
         ecbuild_debug( "Fortran FLAG [${_flag}] removed from build type ${_PAR_BUILD}" )
       endforeach()
 
     elseif( NOT _PAR_BUILD )
 
       foreach( _flag ${_flags} )
-        string(REGEX REPLACE "(^|[ ]+)${flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS} ${CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS}} )
-        string(REGEX REPLACE "(^|[ ]+)${flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS} )
+        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS} ${CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS}} )
+        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS} )
         ecbuild_debug( "Fortran FLAG [${_flag}] removed" )
       endforeach()
 

--- a/cmake/ecbuild_remove_fortran_flags.cmake
+++ b/cmake/ecbuild_remove_fortran_flags.cmake
@@ -44,15 +44,15 @@ macro( ecbuild_remove_fortran_flags m_flags )
     if( _PAR_BUILD AND (CMAKE_BUILD_TYPE_CAPS MATCHES "${_PAR_BUILD_CAPS}") )
 
       foreach( _flag ${_flags} )
-        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${_PAR_BUILD} ${CMAKE_Fortran_FLAGS_${_PAR_BUILD}})
+        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${_PAR_BUILD} "${CMAKE_Fortran_FLAGS_${_PAR_BUILD}}")
         ecbuild_debug( "Fortran FLAG [${_flag}] removed from build type ${_PAR_BUILD}" )
       endforeach()
 
     elseif( NOT _PAR_BUILD )
 
       foreach( _flag ${_flags} )
-        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS} ${CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS}} )
-        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS} )
+        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS} "${CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS}}" )
+        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}" )
         ecbuild_debug( "Fortran FLAG [${_flag}] removed" )
       endforeach()
 


### PR DESCRIPTION
The function `ecbuild_remove_fortran_flags()` uses an incorrect REGEX to remove flags from the Fortran_FLAGS variables.  Specifying flag `-g` (as is done in atlas) will remove the leading `-g` from any flag that starts that way.  e.g., the intel flag `-gcc-name=gcc-9.3.0` -> `cc-name=gcc-9.3.0` -> *BOOM*.

This PR fixes the regex to preserve all other flags.

Test script:
```
function(stripflags flag str)
    string(REGEX REPLACE "(^|[ ]+)${flag}($|[ ]+)" "\\1" out "${str}")
    message("REPLACE FLAG:${flag} Transform: \"${str}\" -> \"${out}\"")
endfunction()

set(flag "-g")
set(tests "-g" " -g" "-g " "-g -foo" "-bar -g -baz" "-ggg -g -gcc -g" "-gcc" "--g -g-" "---g" "   -g" "-g   " "   -g   " "-g-g")

foreach( t IN LISTS tests)
    stripflags(${flag} "${t}")
endforeach()
```

Run as:
```
cmake -P test-script.cmake
```

Output:
```
mjo@wwwyzzerdd ~/work/temp/cmake-regex-test $ cmake -P test-regex.cmake 
REPLACE FLAG:-g Transform: "-g" -> ""
REPLACE FLAG:-g Transform: " -g" -> " "
REPLACE FLAG:-g Transform: "-g " -> ""
REPLACE FLAG:-g Transform: "-g -foo" -> "-foo"
REPLACE FLAG:-g Transform: "-bar -g -baz" -> "-bar -baz"
REPLACE FLAG:-g Transform: "-ggg -g -gcc -g" -> "-ggg -gcc "
REPLACE FLAG:-g Transform: "-gcc" -> "-gcc"
REPLACE FLAG:-g Transform: "--g -g-" -> "--g -g-"
REPLACE FLAG:-g Transform: "---g" -> "---g"
REPLACE FLAG:-g Transform: "   -g" -> "   "
REPLACE FLAG:-g Transform: "-g   " -> ""
REPLACE FLAG:-g Transform: "   -g   " -> "   "
REPLACE FLAG:-g Transform: "-g-g" -> "-g-g"
```
