### PR TITLE
Feature/find gptl

### DIFF
--- a/cmake/FindGPTL.cmake
+++ b/cmake/FindGPTL.cmake
@@ -1,0 +1,72 @@
+# FindGPTL.cmake
+#
+# Copyright UCAR 2020
+
+
+
+#Helper:
+#check_pkg_config(ret_var pcname pcflags...)
+# Check if pcname is known to pkg-config
+# Returns:
+#  Boolean: true if ${pcname}.pc file is found by pkg-config).
+# Args:
+#  ret_var: return variable name.
+#  pcname: pkg-config name to look for (.pc file)
+function(check_pkg_config ret_var pcname)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --exists ${pcname} RESULT_VARIABLE _found)
+    if(_found EQUAL 0)
+        set(${ret_var} True PARENT_SCOPE)
+    else()
+        set(${ret_var} False PARENT_SCOPE)
+    endif()
+endfunction()
+
+#Helper:
+#get_pkg_config(ret_var pcname pcflags...)
+# Get the output of pkg-config
+# Args:
+#  ret_var: return variable name
+#  pcname: pkg-config name to look for (.pc file)
+#  pcflags: pkg-config flags to pass
+function(get_pkg_config ret_var pcname)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} ${ARGN} ${pcname} OUTPUT_VARIABLE _out RESULT_VARIABLE _ret OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(_ret EQUAL 0)
+        separate_arguments(_out)
+        set(${ret_var} ${_out} PARENT_SCOPE)
+    else()
+        set(${ret_var} "" PARENT_SCOPE)
+    endif()
+endfunction()
+
+find_path(TRNG_INCLUDE_DIR NAMES trng/lcg64.hpp PATHS ${TRNG_PREFIX_HINTS} PATH_SUFFIXES include)
+find_library(TRNG_LIBRARY NAMES trng4 PATHS ${TRNG_PREFIX_HINTS} PATH_SUFFIXES lib lib64)
+
+if(TRNG_INCLUDE_DIR)
+    file(READ ${TRNG_INCLUDE_DIR}/trng/config.hpp TRNG_CONFIG)
+    set(TRNG_VER_REGEX "TRNG_VERSION [0-9]+\\.[0-9]+")
+    string(REGEX MATCH ${TRNG_VER_REGEX} TRNG_VER_SUBSTR ${TRNG_CONFIG})
+    string(SUBSTRING ${TRNG_VER_SUBSTR} 13 -1 TRNG_VERSION_STRING)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  TRNG
+  REQUIRED_VARS
+    TRNG_LIBRARY
+    TRNG_INCLUDE_DIR
+  VERSION_VAR
+    TRNG_VERSION_STRING
+)
+
+mark_as_advanced(TRNG_INCLUDE_DIR
+                 TRNG_LIBRARY
+                 TRNG_VERSION_STRING)
+
+if(TRNG_FOUND AND NOT TARGET TRNG::TRNG)
+    get_filename_component(_lib_dir ${TRNG_LIBRARY} DIRECTORY)
+    add_library(TRNG::TRNG INTERFACE IMPORTED)
+    set_target_properties(TRNG::TRNG PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES ${TRNG_INCLUDE_DIR}
+        INTERFACE_LINK_LIBRARIES ${TRNG_LIBRARY})
+    unset(_lib_dir)
+endif()

--- a/cmake/FindGPTL.cmake
+++ b/cmake/FindGPTL.cmake
@@ -97,6 +97,7 @@ find_package_handle_standard_args(
 
 #Hide non-documented variables reserved for internal/advanced usage
 mark_as_advanced(GPTL_VERSION_STRING
+                 GPTL_PREFIX
                  GPTL_INCLUDE_DIR
                  GPTL_MODULE_DIR
                  GPTL_COMPILE_OPTIONS
@@ -108,6 +109,7 @@ mark_as_advanced(GPTL_VERSION_STRING
 #Debugging output
 message(DEBUG "GPTL_FOUND: ${GPTL_FOUND}")
 message(DEBUG "GPTL_VERSION_STRING: ${GPTL_VERSION_STRING}")
+message(DEBUG "GPTL_PREFIX: ${GPTL_PREFIX}")
 message(DEBUG "GPTL_BIN_DIR: ${GPTL_BIN_DIR}")
 message(DEBUG "GPTL_INCLUDE_DIR: ${GPTL_INCLUDE_DIR}")
 message(DEBUG "GPTL_MODULE_DIR: ${GPTL_MODULE_DIR}")

--- a/cmake/FindGPTL.cmake
+++ b/cmake/FindGPTL.cmake
@@ -16,7 +16,7 @@
 #  GPTL::GPTL - Imported interface target to pass to target_link_libraries()
 #
 # NOTE: This find modules uses `pkg-config` to locate GPTL and glean the appropriate flags, directories,
-# and link dependency ordering.  For this to work both a `pkg-config` executable and a `gptl.pc`
+# and link dependency ordering.  For this to work, both a `pkg-config` executable and a `gptl.pc`
 # config file need to be found.
 # * To find the `pkg-config` executable, ensure it is on your PATH.
 #   * For non-standard locations the official CMake FindPkgConfig uses Cmake variable `PKG_CONFIG_EXECUTABLE`
@@ -24,7 +24,7 @@
 # * To find `gptl.pc` ensure it is on the (colon-separated) directories listed in standard pkg-config
 #   environment variable `PKG_CONFIG_PATH`.
 #    * See: https://linux.die.net/man/1/pkg-config
-# * A working GPTL pkg-config install can be confirmed on the command line
+# * A working GPTL pkg-config install can be confirmed on the command line, e.g.,
 #   ```
 #   $ pkg-config --modversion gptl
 #   8.0.2
@@ -35,7 +35,7 @@
 #  $ pkg-config --variable=prefix gptl
 #  /usr/local
 #  ```
-# Only if pkg-config is not supported or available, GPTL will be searched by the standard CMake search procedures.
+# Only when pkg-config is not supported or available, GPTL will be searched by the standard CMake search procedures.
 # Set environment or CMake variable GPTL_ROOT to control this search.  The GPTL_ROOT variable will have no effect
 # if GPTL_HAS_PKG_CONFIG=True.
 #
@@ -117,7 +117,7 @@ Attempting to find GPTL without pkg-config support may cause some required compi
     find_path(GPTL_BIN_DIR NAMES gptl_avail PATH_SUFFIXES bin)
 endif()
 
-#Hide non-documented variables reserved for internal/advanced usage
+#Hide non-documented cache variables reserved for internal/advanced usage
 mark_as_advanced( GPTL_INCLUDE_DIR
                   GPTL_MODULE_DIR
                   GPTL_LIBRARY )
@@ -125,6 +125,7 @@ mark_as_advanced( GPTL_INCLUDE_DIR
 #Debugging output
 message(DEBUG "[FindGPTL] GPTL_FOUND: ${GPTL_FOUND}")
 message(DEBUG "[FindGPTL] GPTL_VERSION_STRING: ${GPTL_VERSION_STRING}")
+message(DEBUG "[FindGPTL] GPTL_HAS_PKG_CONFIG: ${GPTL_HAS_PKG_CONFIG}")
 message(DEBUG "[FindGPTL] GPTL_PREFIX: ${GPTL_PREFIX}")
 message(DEBUG "[FindGPTL] GPTL_BIN_DIR: ${GPTL_BIN_DIR}")
 message(DEBUG "[FindGPTL] GPTL_INCLUDE_DIR: ${GPTL_INCLUDE_DIR}")

--- a/cmake/FindGPTL.cmake
+++ b/cmake/FindGPTL.cmake
@@ -1,8 +1,20 @@
 # FindGPTL.cmake
 #
 # Copyright UCAR 2020
+#
+# Find the GPTL: General Purpose Timing Library (https://jmrosinski.github.io/GPTL/)
+#
+# This find modules uses pkg-config to locate GPTL and glean the appropriate flags, directories, link dependencies.
+#
+# GPTL_FOUND - True if GPTL was found
+# GPTL::GPTL - Imported interface target to pass to target_link_libraries()
+# GPTL_VERSION_STRING - Version of installed GPTL
+# GPTL_BIN_DIR - GPTL binary directory
+# GPTL_HAS_PKG_CONFIG -  Found installed gptl.pc file -- pkg-config support enabled
+#
+#
 
-
+find_package(PkgConfig QUIET)
 
 #Helper:
 #check_pkg_config(ret_var pcname pcflags...)
@@ -13,11 +25,16 @@
 #  ret_var: return variable name.
 #  pcname: pkg-config name to look for (.pc file)
 function(check_pkg_config ret_var pcname)
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --exists ${pcname} RESULT_VARIABLE _found)
-    if(_found EQUAL 0)
-        set(${ret_var} True PARENT_SCOPE)
-    else()
+    if(NOT PKG_CONFIG_FOUND OR NOT EXISTS ${PKG_CONFIG_EXECUTABLE})
         set(${ret_var} False PARENT_SCOPE)
+    else()
+        execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --exists ${pcname} RESULT_VARIABLE _found)
+        message(STATUS "FOUND: ${_found}")
+        if(_found EQUAL 0)
+            set(${ret_var} True PARENT_SCOPE)
+        else()
+            set(${ret_var} False PARENT_SCOPE)
+        endif()
     endif()
 endfunction()
 
@@ -28,8 +45,8 @@ endfunction()
 #  ret_var: return variable name
 #  pcname: pkg-config name to look for (.pc file)
 #  pcflags: pkg-config flags to pass
-function(get_pkg_config ret_var pcname)
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} ${ARGN} ${pcname} OUTPUT_VARIABLE _out RESULT_VARIABLE _ret OUTPUT_STRIP_TRAILING_WHITESPACE)
+function(get_pkg_config ret_var pcname pcflags)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} ${ARGN} ${pcname} ${pcflags} OUTPUT_VARIABLE _out RESULT_VARIABLE _ret OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(_ret EQUAL 0)
         separate_arguments(_out)
         set(${ret_var} ${_out} PARENT_SCOPE)
@@ -38,35 +55,89 @@ function(get_pkg_config ret_var pcname)
     endif()
 endfunction()
 
-find_path(TRNG_INCLUDE_DIR NAMES trng/lcg64.hpp PATHS ${TRNG_PREFIX_HINTS} PATH_SUFFIXES include)
-find_library(TRNG_LIBRARY NAMES trng4 PATHS ${TRNG_PREFIX_HINTS} PATH_SUFFIXES lib lib64)
-
-if(TRNG_INCLUDE_DIR)
-    file(READ ${TRNG_INCLUDE_DIR}/trng/config.hpp TRNG_CONFIG)
-    set(TRNG_VER_REGEX "TRNG_VERSION [0-9]+\\.[0-9]+")
-    string(REGEX MATCH ${TRNG_VER_REGEX} TRNG_VER_SUBSTR ${TRNG_CONFIG})
-    string(SUBSTRING ${TRNG_VER_SUBSTR} 13 -1 TRNG_VERSION_STRING)
+#Attempt to use pkg-config to get as much information as possible
+check_pkg_config(GPTL_HAS_PKG_CONFIG gptl)
+if(GPTL_HAS_PKG_CONFIG)
+    get_pkg_config(GPTL_VERSION_STRING gptl --modversion)
+    get_pkg_config(GPTL_PREFIX gptl --variable=prefix)
+    get_pkg_config(GPTL_INCLUDE_DIR gptl --cflags-only-I)
+    if(GPTL_INCLUDE_DIR)
+        string(REGEX REPLACE "-I([^ ]+)" "\\1;" GPTL_INCLUDE_DIR ${GPTL_INCLUDE_DIR}) #Remove -I
+    endif()
+    get_pkg_config(GPTL_COMPILE_OPTIONS gptl --cflags-only-other)
+    get_pkg_config(GPTL_LINK_LIBRARIES gptl --libs-only-l)
+    get_pkg_config(GPTL_LINK_DIRECTORIES gptl --libs-only-L)
+    if(GPTL_LINK_DIRECTORIES)
+        string(REGEX REPLACE "-L([^ ]+)" "\\1;" GPTL_LINK_DIRECTORIES ${GPTL_LINK_DIRECTORIES}) #Remove -L
+    endif()
+    get_pkg_config(GPTL_LINK_OPTIONS gptl --libs-only-other)
+else()
+    message(WARNING "GPTL: PkgConfig not found.  Unable to query compiler and linker options.  Attempting to find GPTL component paths individually.")
 endif()
+if(NOT GPTL_INCLUDE_DIR)
+    find_path(GPTL_INCLUDE_DIR NAMES gptl.h PATHS ${GPTL_PREFIX_HINTS} PATH_SUFFIXES include include/gptl)
+endif()
+find_path(GPTL_MODULE_DIR NAMES gptl.mod PATHS ${GPTL_PREFIX_HINTS} PATH_SUFFIXES include include/gptl module module/gptl)
+find_path(GPTL_BIN_DIR NAMES gptl_avail PATHS ${GPTL_PREFIX_HINTS} PATH_SUFFIXES bin)
+find_library(GPTL_LIBRARY NAMES gptl PATHS ${GPTL_PREFIX_HINTS} PATH_SUFFIXES lib lib64)
 
+
+#Check package has been found correctly
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  TRNG
+  GPTL
   REQUIRED_VARS
-    TRNG_LIBRARY
-    TRNG_INCLUDE_DIR
+    GPTL_LIBRARY
+    GPTL_INCLUDE_DIR
+    GPTL_MODULE_DIR
+    GPTL_BIN_DIR
   VERSION_VAR
-    TRNG_VERSION_STRING
+    GPTL_VERSION_STRING
 )
 
-mark_as_advanced(TRNG_INCLUDE_DIR
-                 TRNG_LIBRARY
-                 TRNG_VERSION_STRING)
+#Hide non-documented variables reserved for internal/advanced usage
+mark_as_advanced(GPTL_VERSION_STRING
+                 GPTL_INCLUDE_DIR
+                 GPTL_MODULE_DIR
+                 GPTL_COMPILE_OPTIONS
+                 GPTL_LIBRARY
+                 GPTL_LINK_LIBRARIES
+                 GPTL_LINK_DIRECTORIES
+                 GPTL_LINK_OPTIONS)
 
-if(TRNG_FOUND AND NOT TARGET TRNG::TRNG)
-    get_filename_component(_lib_dir ${TRNG_LIBRARY} DIRECTORY)
-    add_library(TRNG::TRNG INTERFACE IMPORTED)
-    set_target_properties(TRNG::TRNG PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES ${TRNG_INCLUDE_DIR}
-        INTERFACE_LINK_LIBRARIES ${TRNG_LIBRARY})
-    unset(_lib_dir)
+#Debugging output
+message(DEBUG "GPTL_FOUND: ${GPTL_FOUND}")
+message(DEBUG "GPTL_VERSION_STRING: ${GPTL_VERSION_STRING}")
+message(DEBUG "GPTL_BIN_DIR: ${GPTL_BIN_DIR}")
+message(DEBUG "GPTL_INCLUDE_DIR: ${GPTL_INCLUDE_DIR}")
+message(DEBUG "GPTL_MODULE_DIR: ${GPTL_MODULE_DIR}")
+message(DEBUG "GPTL_LIBRARY: ${GPTL_LIBRARY}")
+message(DEBUG "GPTL_LINK_LIBRARIES: ${GPTL_LINK_LIBRARIES}")
+message(DEBUG "GPTL_LINK_DIRECTORIES: ${GPTL_LINK_DIRECTORIES}")
+message(DEBUG "GPTL_LINK_OPTIONS: ${GPTL_LINK_OPTIONS}")
+
+#Create GPTL::GPTL imported interface target
+if(GPTL_FOUND AND NOT TARGET GPTL::GPTL)
+    add_library(GPTL::GPTL INTERFACE IMPORTED)
+    set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${GPTL_INCLUDE_DIR})
+    if(GPTL_MODULE_DIR)
+        set_property(TARGET GPTL::GPTL APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${GPTL_MODULE_DIR})
+    endif()
+    if(GPTL_COMPILE_OPTIONS)
+        set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_COMPILE_OPTIONS ${GPTL_COMPILE_OPTIONS})
+    endif()
+    if(GPTL_LINK_DIRECTORIES)
+        set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_LINK_DIRECTORIES ${GPTL_LINK_DIRECTORIES})
+    endif()
+    if(GPTL_LINK_OPTIONS)
+        set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_LINK_OPTIONS ${GPTL_LINK_OPTIONS})
+    endif()
+    if(GPTL_LINK_LIBRARIES)
+        set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_LINK_LIBRARIES ${GPTL_LINK_LIBRARIES})
+    else()
+        set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_LINK_LIBRARIES ${GPTL_LIBRARY})
+        get_filename_component(_lib_dir ${GPTL_LIBRARY} DIRECTORY)
+        set_property(TARGET GPTL::GPTL APPEND PROPERTY INTERFACE_LINK_DIRECTORIES ${_lib_dir})
+        unset(_lib_dir)
+    endif()
 endif()


### PR DESCRIPTION
Here is a hopefully nearly complete implementation of `FindGPTL.cmake` that attempts to use `pkg-config` to obtain as much information about the GPTL installation and directories as possible.  Please see the comments for a complete description of exported variables.  This find module exports the `GPTL::GPTL` imported interface target which should be used with `target_link_libraries()` to add GPTL support to any CMake target (executable or library).

To test I've made a very simple CMake project with a single executable based of an example provided by @jmrosinski.  See the [testgptl repository](https://github.com/markjolah/testgptl) for details on how to test.

I have not fully tested the output as the `testgptl` executable is currently producing the following warning:
```
PAPI Error: Error finding event OFFCORE_RESPONSE_0:SNP_FWD, it is used in derived event PAPI_CA_ITV.
```

I get the same error running the `gptl_avail` excutable provided by GPTL itself:
```
mjo@wwwyzzerdd ~/work/github/testgptl/_build $ gptl_avail 

PAPI Error: Error finding event OFFCORE_RESPONSE_0:SNP_FWD, it is used in derived event PAPI_CA_ITV.
Purpose: print derived events available on this architecture
Note: 'available' may require enabling multiplexing in some cases
For PAPI-specific events, run papi_avail and papi_native_avail from the PAPI distribution

Available derived events:
Name                Code        Description
-------------------------------------------
GPTL_IPC             17         Instructions per cycle
GPTL_LSTPI           21         Load-store instruction fraction
GPTL error:GPTL_PAPIsetoption: GPTL_DCMRT unavailable
GPTL error:GPTLsetoption: failure to enable option 22
GPTL_LSTPDCM         23         Load-store instructions per L1 miss
GPTL_L2MRT           24         L2 Miss rate (fraction)
GPTL_LSTPL2M         25         Load-store instructions per L2 miss
GPTL_L3MRT           26         L3 Miss rate (fraction)
```

I will investigate if this is a problem with my install of GPTL or the version of PAPI in use.  Perhaps @jmrosinski has seen this error message before?

Additional contributions and fixes are welcome.