### PR TITLE
Use CMAKE_INSTALL_LIB_DIR as default for INSTALL_LIB_DIR

### DIFF
--- a/cmake/ecbuild_declare_project.cmake
+++ b/cmake/ecbuild_declare_project.cmake
@@ -118,11 +118,12 @@ if( NOT ${PROJECT_NAME}_DECLARED )
   # install dirs for this project
 
   # Use defaults unless values are already present in cache
+  include(GNUInstalDirs)
   if( NOT INSTALL_BIN_DIR )
     set( INSTALL_BIN_DIR bin )
   endif()
   if( NOT INSTALL_LIB_DIR )
-    set( INSTALL_LIB_DIR lib )
+    set( INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR} )
   endif()
   if( NOT INSTALL_INCLUDE_DIR )
     set( INSTALL_INCLUDE_DIR include )

--- a/cmake/ecbuild_declare_project.cmake
+++ b/cmake/ecbuild_declare_project.cmake
@@ -118,7 +118,7 @@ if( NOT ${PROJECT_NAME}_DECLARED )
   # install dirs for this project
 
   # Use defaults unless values are already present in cache
-  include(GNUInstalDirs)
+  include(GNUInstallDirs)
   if( NOT INSTALL_BIN_DIR )
     set( INSTALL_BIN_DIR bin )
   endif()


### PR DESCRIPTION
Ecbuild hardcodes the default library install location to lib, which is not a valid library install location on many platforms, e.g., those that use lib64 or multi-tiered lib/<multi-arch> directories with multiarch support. The CMake GNUInstallDirs module sets the default CMake install locations on a per-platform basis. Defaulting the INSTALL_LIB_DIR to the value of CMAKE_INSTALL_LIBDIR will allow ecbuild enabled packages to be installed to the correct system-dependent locations, as determined by CMake.

This PR has also been submitted upstream as [ecmwf/ecbuild # 29](https://github.com/ecmwf/ecbuild/pull/29).  

However this issue will require a hotfix, as it is currently a blocker for adding normal CMake packages into an ecbuild bundle, which in turn is blocking several PRs I have ready.   

Unless the bundle explicitly sets INSTALL_LIB_DIR to equal to CMAKE_INSTALL_LIBDIR and then reinitializes `ecbuild_declare_project`, there can be incompatible installations.   All the ecbuild packages will end up under `<prefix>/lib` and all the other normal CMake packages may end up under `<prefix>/lib64`  (on systems where that is the normal location) and the libraries won't be able to find each other at runtime from the installation prefix.  This won't be apparent in the build directory or during ctests, but after installation things will break.